### PR TITLE
Fix: Update container group creation operation

### DIFF
--- a/src/aci_docs_sample.py
+++ b/src/aci_docs_sample.py
@@ -188,7 +188,7 @@ def create_container_group_multi(aci_client, resource_group,
                            ip_address=group_ip_address)
 
     # Create the container group
-    aci_client.container_groups.create_or_update(resource_group.name,
+    aci_client.container_groups.begin_create_or_update(resource_group.name,
                                                  container_group_name, group)
 
     # Get the created container group
@@ -249,7 +249,7 @@ def run_task_based_container(aci_client, resource_group, container_group_name,
                            restart_policy=ContainerGroupRestartPolicy.never)
 
     # Create the container group
-    result = aci_client.container_groups.create_or_update(resource_group.name,
+    result = aci_client.container_groups.begin_create_or_update(resource_group.name,
                                                           container_group_name,
                                                           group)
 


### PR DESCRIPTION


## Purpose
Fixes the container group creation operation by invoking the method `begin_create_or_update ` instead of `begin_create_or_update ` which must have been deprecated at some point.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```